### PR TITLE
Updated reading of mgf files

### DIFF
--- a/Kaiko_4.py
+++ b/Kaiko_4.py
@@ -163,8 +163,8 @@ EXCLUDED_RANKS = ['family','order','class','phylum','kingdom','superkingdom']
 # diamond_search_out = Path("Kaiko_volume/Kaiko_intermediate/" + prefix + "_diamond_search_output.dmd")
 # kaiko_tally = Path("Kaiko_volume/Kaiko_intermediate/" + prefix + "_kaiko_prediction_top_taxa.csv")
 # ncbi_taxa_folder = Path(PureWindowsPath("Kaiko_volume/Kaiko_stationary_files/ncbi_taxa").as_posix())
-# nprot = '{:.5e}'.format(int(150000))
-# kaiko_tally = Path("Kaiko_volume/Kaiko_intermediate/" + prefix + "_kaiko_prediction" + f'_top_taxa_nprot_{nprot}_top_{5}_strains.csv')
+# nprot = '{:.5e}'.format(int(117000))
+# kaiko_tally = Path("Kaiko_volume/Kaiko_intermediate/" + prefix + "_kaiko_prediction" + f'_top_taxa_nprot_{nprot}_top_{1}_strains.csv')
 # ref_fasta = Path(PureWindowsPath('Kaiko_volume/Kaiko_stationary_files/uniref100.fasta.gz').as_posix())
 # kaiko_final_output = Path("Kaiko_volume/Kaiko_output/" + prefix + "_kaiko_output.fasta")
 
@@ -172,5 +172,9 @@ EXCLUDED_RANKS = ['family','order','class','phylum','kingdom','superkingdom']
 #                 kaiko_tally,
 #                 kaiko_final_output,
 #                 0.66,
+#                 1,
+#                 ncbi_taxa_folder,
 #                 'TaxID',
 #                 [])
+
+# aggregate_fasta(ref_fasta, diamon_tally, fout, coverage_target, top_strains, ncbi_taxa_folder, taxa_key, kingdom_list = [])


### PR DESCRIPTION
The old method was dependent on a very specific order and number of header variables in the mgf spectrum. Now the new method accepts variable lengths, though it requires PEPMASS and CHARGE, scan can be inferred from the title when missing.

Needed to read the mgf files from Kansas soil